### PR TITLE
clear tablet and phone statuses for unknown mobile. Fixes #20

### DIFF
--- a/generate/mobile-detect.template.js
+++ b/generate/mobile-detect.template.js
@@ -173,7 +173,8 @@ define(function () {
         if (isMobileFallback(userAgent)) {
             phoneSized = MobileDetect.isPhoneSized(maxPhoneWidth);
             if (phoneSized === undefined) {
-                cache.mobile = cache.tablet = cache.phone = FALLBACK_MOBILE;
+                cache.mobile = FALLBACK_MOBILE;
+                cache.tablet = cache.phone = null;
             } else if (phoneSized) {
                 cache.mobile = cache.phone = FALLBACK_PHONE;
                 cache.tablet = null;

--- a/mobile-detect.js
+++ b/mobile-detect.js
@@ -430,7 +430,8 @@ define(function () {
         if (isMobileFallback(userAgent)) {
             phoneSized = MobileDetect.isPhoneSized(maxPhoneWidth);
             if (phoneSized === undefined) {
-                cache.mobile = cache.tablet = cache.phone = FALLBACK_MOBILE;
+                cache.mobile = FALLBACK_MOBILE;
+                cache.tablet = cache.phone = null;
             } else if (phoneSized) {
                 cache.mobile = cache.phone = FALLBACK_PHONE;
                 cache.tablet = null;


### PR DESCRIPTION
Will return falsy values for phone() and tablet() if device is "UnknownMobile". It'll make tablet/phone determining more straightforward. 

