### PR TITLE
Added phoneType function

### DIFF
--- a/mobile-detect.js
+++ b/mobile-detect.js
@@ -746,6 +746,16 @@ define(function () {
         },
 
         /**
+         * Only working on Webkit! And only tested on Android
+         * If we got the phone from the above function the string between phone and the 'Build' number returns the phone type
+         */
+        phoneType: function() {
+            if(this.version('Webkit') && this.os() === 'AndroidOS') {
+                return this.ua.substring(this.ua.indexOf(this.phone()), this.ua.indexOf('Build') -1);
+            }
+        },
+
+        /**
          * Returns the detected tablet type/family string or <tt>null</tt>.
          * <br>
          * The returned tablet (family or producer) is one of following keys:<br>


### PR DESCRIPTION
Hi, I need to get the actual phone Type not only the manufacturer or vendor from the userAgent string. As it looks the type is available on WebKit phones on AndroidOS. I don't have many Android phones to test (only three) but it works on those. Also, the algorithm might not be sufficient for all cases. 

I'd like to get some feedback on this proposed feature (function) for mobile-detect.js. I'm happy to adapt the code or follow another path, just let me know.

Thanks
